### PR TITLE
fixing - FutureWarning: elementwise comparison failed;

### DIFF
--- a/io3d/misc.py
+++ b/io3d/misc.py
@@ -264,12 +264,12 @@ def resize_to_mm(data3d, voxelsize_mm, new_voxelsize_mm, mode='nearest'):
     import scipy
     import scipy.ndimage
 
-    if new_voxelsize_mm == 'orig':
+    if np.all(new_voxelsize_mm == 'orig'):
         new_voxelsize_mm = np.array(voxelsize_mm)
 
-    elif new_voxelsize_mm == 'orig*2':
+    elif np.all(new_voxelsize_mm == 'orig*2'):
         new_voxelsize_mm = np.array(voxelsize_mm) * 2
-    elif new_voxelsize_mm == 'orig*4':
+    elif np.all(new_voxelsize_mm == 'orig*4'):
         new_voxelsize_mm = np.array(voxelsize_mm) * 4
         # vx_size = np.array(metadata['voxelsize_mm']) * 4
 


### PR DESCRIPTION
Tento PR by měl spravit tyhle otravné varování z numpy:
```
/home/travis/miniconda/envs/travis/lib/python2.7/site-packages/io3d/misc.py:267: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  if new_voxelsize_mm == 'orig':
/home/travis/miniconda/envs/travis/lib/python2.7/site-packages/io3d/misc.py:270: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  elif new_voxelsize_mm == 'orig*2':
/home/travis/miniconda/envs/travis/lib/python2.7/site-packages/io3d/misc.py:272: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  elif new_voxelsize_mm == 'orig*4':
```