### PR TITLE
fix bytes/string issue

### DIFF
--- a/io3d/dcmreaddata.py
+++ b/io3d/dcmreaddata.py
@@ -140,6 +140,8 @@ class DicomReader:
     ):
         self.valid = False
         self.dirpath = os.path.expanduser(dirpath)
+        if isinstance(self.dirpath, bytes):
+            self.dirpath = self.dirpath.decode()
         self.dicomdirectory = DicomDirectory(
             self.dirpath,
             force_create_dicomdir=force_create_dicomdir,


### PR DESCRIPTION
Functions of `os.path` module can return bytes, not string. This PR ensures that `self.dirpath` is string.